### PR TITLE
Added Auxiliary Circle Feature For Ellipse

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -543,6 +543,36 @@ class Ellipse(GeometrySet):
         """
         return Point.distance(self.center, self.foci[0])
 
+    def auxiliary_circle(self, x='x', y='y'):
+        """The equation of auxiliary circle of the ellipse.
+
+        Returns
+        =======
+
+        equation : sympy expression
+
+        Parameters
+        ==========
+
+        x : str, optional Label for the x-axis. Default value is 'x'.
+        y : str, optional Label for the y-axis. Default value is 'y'.
+
+        Examples
+        ========
+
+        >>> from sympy import Ellipse, Point
+        >>> ellipse = Ellipse(Point(2, 4), 9, 1)
+        >>> ellipse.auxiliary_circle()
+        (x - 2)**2 + (y - 4)**2 - 81
+
+        """
+        x = _symbol(x)
+        y = _symbol(y)
+        m =_symbol(m)
+        hr, vr = self.hradius, self.vradius
+        m = max(hr, vr)
+        return (x - self.center.x)**2 + (y - self.center.y)**2 - m**2
+
     @property
     def hradius(self):
         """The horizontal radius of the ellipse.


### PR DESCRIPTION
Auxiliary Circle of an ellipse is circumcircle of an ellipse i.e. the circle whose center concurs with that of the ellipse and whose radius is equal to the ellipse's semi-major axis.

The center of the auxiliary circle is always the same as the ellipse's center, the circle itself touches both vertices. Hence, the distance between a vertex and the center is the circle's radius. In an ellipse, the distance between a vertex and the center is given by the semi-major axis. 

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

#### Other comments

This is my first pull request so i hope guidance and feedback from fellow mentors.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- geometry
  - Added Auxiliary Circle Feature For Ellipse

<!-- END RELEASE NOTES -->
