### PR TITLE
Added Functions for Amicable Number

### DIFF
--- a/sympy/ntheory/__init__.py
+++ b/sympy/ntheory/__init__.py
@@ -9,7 +9,7 @@ from .factor_ import divisors, factorint, multiplicity, perfect_power, \
     pollard_pm1, pollard_rho, primefactors, totient, trailing, divisor_count, \
     divisor_sigma, factorrat, reduced_totient, primenu, primeomega, \
     mersenne_prime_exponent, is_perfect, is_mersenne_prime, is_abundant, \
-    is_deficient, abundance
+    is_deficient, is_amicable, abundance
 from .partitions_ import npartitions
 from .residue_ntheory import is_primitive_root, is_quad_residue, \
     legendre_symbol, jacobi_symbol, n_order, sqrt_mod, quadratic_residues, \

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2214,7 +2214,7 @@ def is_amicable(n, N):
     >>> from sympy.ntheory.factor_ import divisor_sigma
     >>> is_amicable(3259, 4576)
     False
-    >>> is_amicable(6232, 6368)
+    >>> is_amicable(5020, 5564)
     True
 
     References

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2203,15 +2203,15 @@ def is_deficient(n):
     return bool(abundance(n) < 0)
 
 
-def is_amicable(n, N):
-    """Returns True if the pair ``(n, N)`` is a Amicable Number, else False.
+def is_amicable(m, n):
+    """Returns True if the pair ``(m, n)`` is a Amicable Number, else False.
 
     Amicable numbers are two different numbers so related that the sum of the proper divisors of each is equal to the other number.
 
     Examples
     ========
 
-    >>> from sympy import *
+    >>> from sympy.ntheory.factor_ import is_deficient
     >>> is_amicable(3259, 4576)
     False
     >>> is_amicable(5020, 5564)
@@ -2223,7 +2223,7 @@ def is_amicable(n, N):
     .. [1] https://en.wikipedia.org/wiki/Amicable_numbers
 
     """
-    if((divisor_sigma(n, 1)) - n == N and (divisor_sigma(N, 1)) - N == n ):
+    if((divisor_sigma(m, 1)) - m == n and (divisor_sigma(n, 1)) - n == m ):
         return True
     else:
         return False

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2223,7 +2223,7 @@ def is_amicable(n, N):
     .. [1] https://en.wikipedia.org/wiki/Amicable_numbers
 
     """
-    if((divisor_sigma(n)) - n == N and (divisor_sigma(N)) - N == n ):
+    if((divisor_sigma(n, 1)) - n == N and (divisor_sigma(N, 1)) - N == n ):
         return True
     else:
         return False

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2201,3 +2201,29 @@ def is_deficient(n):
     if is_perfect(n):
         return False
     return bool(abundance(n) < 0)
+
+
+def is_amicable(n, N):
+    """Returns True if the pair ``(n, N)`` is a Amicable Number, else False.
+
+    Amicable numbers are two different numbers so related that the sum of the proper divisors of each is equal to the other number.
+
+    Examples
+    ========
+
+    >>> from sympy.ntheory.factor_ import divisor_sigma
+    >>> is_amicable(3259, 4576)
+    False
+    >>> is_amicable(6232, 6368)
+    True
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Amicable_numbers
+
+    """
+    if((divisor_sigma(n)) - n == N and (divisor_sigma(N)) - N == n ):
+        return True
+    else:
+        return False

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2228,4 +2228,3 @@ def is_amicable(m, n):
         return True
     else:
         return False
-    

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2204,18 +2204,18 @@ def is_deficient(n):
 
 
 def is_amicable(m, n):
-    """Returns True if the pair `(m, n)` is an Amicable Number, else False.
+    """Returns True if the numbers `m` and `n` are "amicable", else False.
 
     Amicable numbers are two different numbers so related that the sum
-    of the proper divisors of each is equal to the other number.
+    of the proper divisors of each is equal to that of the other.
 
     Examples
     ========
 
-    >>> from sympy.ntheory.factor_ import is_amicable
-    >>> is_amicable(3259, 4576)
-    False
-    >>> is_amicable(5020, 5564)
+    >>> from sympy.ntheory.factor_ import is_amicable, divisor_sigma
+    >>> is_amicable(220, 284)
+    True
+    >>> divisor_sigma(220) == divisor_sigma(284)
     True
 
     References

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2204,14 +2204,15 @@ def is_deficient(n):
 
 
 def is_amicable(m, n):
-    """Returns True if the pair (m, n) is a Amicable Number, else False.
+    """Returns True if the pair `(m, n)` is a Amicable Number, else False.
 
-    Amicable numbers are two different numbers so related that the sum of the proper divisors of each is equal to the other number.
+    Amicable numbers are two different numbers so related that the sum
+    of the proper divisors of each is equal to the other number.
 
     Examples
     ========
 
-    >>> from sympy.ntheory.factor_ import is_amicable
+    >>> from sympy.ntheory.factor_ import divisor_sigma, is_amicable
     >>> is_amicable(3259, 4576)
     False
     >>> is_amicable(5020, 5564)
@@ -2227,3 +2228,4 @@ def is_amicable(m, n):
         return True
     else:
         return False
+    

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2224,7 +2224,5 @@ def is_amicable(m, n):
     .. [1] https://en.wikipedia.org/wiki/Amicable_numbers
 
     """
-    if((divisor_sigma(m, 1)) - m == n and (divisor_sigma(n, 1)) - n == m ):
-        return True
-    else:
-        return False
+    a, b = map(lambda i: divisor_sigma(i), (m, n))
+    return a == b == (m + n)

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2211,7 +2211,7 @@ def is_amicable(n, N):
     Examples
     ========
 
-    >>> from sympy.ntheory.factor_ import divisor_sigma
+    >>> from sympy import *
     >>> is_amicable(3259, 4576)
     False
     >>> is_amicable(5020, 5564)

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2204,7 +2204,7 @@ def is_deficient(n):
 
 
 def is_amicable(m, n):
-    """Returns True if the pair ``(m, n)`` is a Amicable Number, else False.
+    """Returns True if the pair (m, n) is a Amicable Number, else False.
 
     Amicable numbers are two different numbers so related that the sum of the proper divisors of each is equal to the other number.
 

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2211,7 +2211,7 @@ def is_amicable(m, n):
     Examples
     ========
 
-    >>> from sympy.ntheory.factor_ import is_deficient
+    >>> from sympy.ntheory.factor_ import is_amicable
     >>> is_amicable(3259, 4576)
     False
     >>> is_amicable(5020, 5564)

--- a/sympy/ntheory/factor_.py
+++ b/sympy/ntheory/factor_.py
@@ -2204,7 +2204,7 @@ def is_deficient(n):
 
 
 def is_amicable(m, n):
-    """Returns True if the pair `(m, n)` is a Amicable Number, else False.
+    """Returns True if the pair `(m, n)` is an Amicable Number, else False.
 
     Amicable numbers are two different numbers so related that the sum
     of the proper divisors of each is equal to the other number.
@@ -2212,7 +2212,7 @@ def is_amicable(m, n):
     Examples
     ========
 
-    >>> from sympy.ntheory.factor_ import divisor_sigma, is_amicable
+    >>> from sympy.ntheory.factor_ import is_amicable
     >>> is_amicable(3259, 4576)
     False
     >>> is_amicable(5020, 5564)
@@ -2224,5 +2224,7 @@ def is_amicable(m, n):
     .. [1] https://en.wikipedia.org/wiki/Amicable_numbers
 
     """
+    if m == n:
+        return False
     a, b = map(lambda i: divisor_sigma(i), (m, n))
     return a == b == (m + n)

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -606,8 +606,8 @@ def test_is_deficient():
     assert is_deficient(56) is False
     assert is_deficient(20) is False
     assert is_deficient(36) is False
-    
-    
+
+
 def test_is_amicable():
     assert is_amicable(173, 129) is False
     assert is_amicable(220, 284) is True

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -14,7 +14,7 @@ from sympy.ntheory import (isprime, n_order, is_primitive_root,
 from sympy.ntheory.factor_ import (smoothness, smoothness_p,
     antidivisors, antidivisor_count, core, digits, udivisors, udivisor_sigma,
     udivisor_count, primenu, primeomega, small_trailing, mersenne_prime_exponent,
-    is_perfect, is_mersenne_prime, is_abundant, is_deficient)
+    is_perfect, is_mersenne_prime, is_abundant, is_deficient, is_amicable)
 from sympy.ntheory.generate import cycle_length
 from sympy.ntheory.multinomial import (
     multinomial_coefficients, multinomial_coefficients_iterator)
@@ -606,3 +606,12 @@ def test_is_deficient():
     assert is_deficient(56) is False
     assert is_deficient(20) is False
     assert is_deficient(36) is False
+    
+    
+def test_is_amicable():
+    assert is_amicable(173, 129) is False
+    assert is_amicable(220, 284) is True
+    assert is_amicable(5410, 1855) is False
+    assert is_amicable(6232, 6368) is True
+    assert is_amicable(23594, 15945) is False
+    assert is_amicable(63020, 76084) is True

--- a/sympy/ntheory/tests/test_factor_.py
+++ b/sympy/ntheory/tests/test_factor_.py
@@ -611,7 +611,4 @@ def test_is_deficient():
 def test_is_amicable():
     assert is_amicable(173, 129) is False
     assert is_amicable(220, 284) is True
-    assert is_amicable(5410, 1855) is False
-    assert is_amicable(6232, 6368) is True
-    assert is_amicable(23594, 15945) is False
-    assert is_amicable(63020, 76084) is True
+    assert is_amicable(8756, 8756) is False


### PR DESCRIPTION
Amicable numbers are two different numbers so related that the sum of the proper divisors of each is equal to the other number. A proper divisor of a number is a positive factor of that number other than the number itself. For example, the proper divisors of 6 are 1, 2, and 3.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### Brief description of what is fixed or changed

Added Functions for Amicable Number with test cases

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- ntheory
  - Added Functions for Amicable Number

<!-- END RELEASE NOTES -->
