### PR TITLE
Added Director Circle Feature For Ellipse

### DIFF
--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1031,7 +1031,7 @@ class Ellipse(GeometrySet):
             A director circle returned as a geometric object.
         Examples
         ========
-        >>> from sympy import Circle, Ellipse, Point, symbols
+        >>> from sympy import Circle, Ellipse, Point, symbols, sqrt
         >>> c = Point(3,8)
         >>> Ellipse(c, 7, 9).director_circle()
         Circle(Point2D(3, 8), sqrt(130))

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1023,7 +1023,8 @@ class Ellipse(GeometrySet):
         return Circle(self.center, Max(self.hradius, self.vradius))
 
     def director_circle(self):
-        """Returns a Circle consisting of all points where two perpendicular
+        """
+        Returns a Circle consisting of all points where two perpendicular
         tangent lines to the ellipse cross each other.
 
         Returns

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1025,22 +1025,29 @@ class Ellipse(GeometrySet):
     def director_circle(self):
         """Returns a Circle consisting of all points where two perpendicular
         tangent lines to the ellipse cross each other.
+
         Returns
         =======
+
         Circle
             A director circle returned as a geometric object.
+
         Examples
         ========
-        >>> from sympy import Circle, Ellipse, Point, symbols, sqrt
+
+        >>> from sympy import Circle, Ellipse, Point, symbols
         >>> c = Point(3,8)
         >>> Ellipse(c, 7, 9).director_circle()
         Circle(Point2D(3, 8), sqrt(130))
         >>> a, b = symbols('a b')
         >>> Ellipse(c, a, b).director_circle()
         Circle(Point2D(3, 8), sqrt(a**2 + b**2))
+
         References
         ==========
+
         .. [1] https://en.wikipedia.org/wiki/Director_circle
+
         """
         return Circle(self.center, sqrt(self.hradius**2 + self.vradius**2))
 

--- a/sympy/geometry/ellipse.py
+++ b/sympy/geometry/ellipse.py
@@ -1022,6 +1022,28 @@ class Ellipse(GeometrySet):
         """
         return Circle(self.center, Max(self.hradius, self.vradius))
 
+    def director_circle(self):
+        """Returns a Circle consisting of all points where two perpendicular
+        tangent lines to the ellipse cross each other.
+        Returns
+        =======
+        Circle
+            A director circle returned as a geometric object.
+        Examples
+        ========
+        >>> from sympy import Circle, Ellipse, Point, symbols
+        >>> c = Point(3,8)
+        >>> Ellipse(c, 7, 9).director_circle()
+        Circle(Point2D(3, 8), sqrt(130))
+        >>> a, b = symbols('a b')
+        >>> Ellipse(c, a, b).director_circle()
+        Circle(Point2D(3, 8), sqrt(a**2 + b**2))
+        References
+        ==========
+        .. [1] https://en.wikipedia.org/wiki/Director_circle
+        """
+        return Circle(self.center, sqrt(self.hradius**2 + self.vradius**2))
+
     def plot_interval(self, parameter='t'):
         """The plot interval for the default geometric plot of the Ellipse.
 

--- a/sympy/geometry/tests/test_ellipse.py
+++ b/sympy/geometry/tests/test_ellipse.py
@@ -494,3 +494,12 @@ def test_auxiliary_circle():
     assert e.auxiliary_circle() == Circle((x, y), Max(a, b))
     # a special case where Ellipse is a Circle
     assert Circle((3, 4), 8).auxiliary_circle() == Circle((3, 4), 8)
+
+
+def test_director_circle():
+    x, y, a, b = symbols('x y a b')
+    e = Ellipse((x, y), a, b)
+    # the general result
+    assert e.director_circle() == Circle((x, y), sqrt(a**2 + b**2))
+    # a special case where Ellipse is a Circle
+    assert Circle((3, 4), 8).director_circle() == Circle((3, 4), 8*sqrt(2))


### PR DESCRIPTION
Co-authored-by: Ashwin Shenoy <Ashwin-Shenoy-NITK@users.noreply.github.com>
Co-authored-by: ackerman <vishal-vardhan@users.noreply.github.com>

The Director Circle of an ellipse (also called the orthoptic circle or Fermat–Apollonius circle) is a circle consisting of all points where two perpendicular tangent lines to the ellipse cross each other.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
Closes #15148
Closes #15771

<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests .-->

#### Other comments

I hope guidance and feedback from fellow mentors.

#### Release Notes

<!-- Write the release notes for this release below. See
https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more information
on how to write release notes. The bot will check your release notes
automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

- geometry
  - Added Director Circle Feature For Ellipse

<!-- END RELEASE NOTES -->
